### PR TITLE
Get rid of "latest" index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@
 
 FROM logstash
 
-COPY logstash.conf .
+COPY logstash.conf /etc/logstash/conf.d
 
-CMD ["logstash", "-f", "logstash.conf", "--allow-env"]
+CMD ["logstash", "-f", "/etc/logstash/conf.d", "--allow-env"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the COPYING file.
 
-FROM logstash:2.3.1
+FROM logstash
 
 COPY logstash.conf .
 

--- a/logstash.conf
+++ b/logstash.conf
@@ -13,8 +13,8 @@ input {
 
 filter {
   date {
-    match => [ "_timestamp", "UNIX_MS" ]
-    remove_field => [ "_timestamp" ]
+    match => [ "timestamp", "UNIX_MS" ]
+    remove_field => [ "timestamp" ]
   }
 }
 

--- a/logstash.conf
+++ b/logstash.conf
@@ -6,8 +6,6 @@ input {
   kafka {
     zk_connect => "${ZK_CONNECT:localhost:2181}"
     topic_id => "ockafka"
-    decorate_events => true
-    key_decoder_class => "kafka.serializer.StringDecoder"
   }
 }
 
@@ -19,15 +17,6 @@ filter {
 }
 
 output {
-  # This shows the current state of the entire switch
-  elasticsearch {
-    hosts => ["${ES_HOST:127.0.0.1}"]
-    document_id => "%{[kafka][key]}"
-    index => "latest"
-    action => "update"
-    doc_as_upsert => true
-  }
-  # This shows the individual updates
   elasticsearch {
     hosts => ["${ES_HOST:127.0.0.1}"]
     index => "logstash-%{+YYYY.MM.dd}"

--- a/logstash.conf
+++ b/logstash.conf
@@ -14,6 +14,9 @@ filter {
     match => [ "timestamp", "UNIX_MS" ]
     remove_field => [ "timestamp" ]
   }
+  geoip {
+    source => "dataset"
+  }
 }
 
 output {


### PR DESCRIPTION
The `latest` index is impossible to maintain without keeping track of the entire state of all switches, hence it is more efficient to reconstruct it on demand from the notifications if needed.